### PR TITLE
Fix a flaky test testUserController

### DIFF
--- a/2.x/chapter2-1/src/test/java/com/didispace/chapter21/Chapter21ApplicationTests.java
+++ b/2.x/chapter2-1/src/test/java/com/didispace/chapter21/Chapter21ApplicationTests.java
@@ -49,7 +49,7 @@ public class Chapter21ApplicationTests {
         request = get("/users/");
         mvc.perform(request)
                 .andExpect(status().isOk())
-                .andExpect(content().string(equalTo("[{\"id\":1,\"name\":\"测试大师\",\"age\":20}]")));
+                .andExpect(content().json("[{\"id\":1,\"name\":\"测试大师\",\"age\":20}]"));
 
         // 4、put修改id为1的user
         request = put("/users/1")
@@ -61,7 +61,7 @@ public class Chapter21ApplicationTests {
         // 5、get一个id为1的user
         request = get("/users/1");
         mvc.perform(request)
-                .andExpect(content().string(equalTo("{\"id\":1,\"name\":\"测试终极大师\",\"age\":30}")));
+                .andExpect(content().json("{\"id\":1,\"name\":\"测试终极大师\",\"age\":30}"));
 
         // 6、del删除id为1的user
         request = delete("/users/1");


### PR DESCRIPTION
This PR is to fix a flaky test `com.didispace.chapter21.Chapter21ApplicationTests#testUserController` in module `2.x/chapter2-1`, we found it when using the latest version of SpringBoot-Learning:
1. To reproduce test failures:
- Run the following cmds:
```
 mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl 2.x/chapter2-1 -Dtest=com.didispace.chapter21.Chapter21ApplicationTests#testUserController -DnondexRuns=10
```
- Then we'll get failures:
```
Chapter21ApplicationTests.testUserController:52 Response content
Expected: "[{\"id\":1,\"name\":\"测试大师\",\"age\":20}]" but: was "[{\"age\":20,\"name\":\"测试大师\",\"id\":1}]"
```
2. Why it fails:
Line 52 of `2.x/chapter2-1/src/test/java/com/didispace/chapter21/Chapter21ApplicationTests.java` converts a JSON object to a string. Note that this conversion does not guarantee the order of the elements.

4. Fix:
Use `json()` to compare Json objects instead of converting them to string.